### PR TITLE
Added Support for Read The Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+sphinx:
+   configuration: docsrc/conf.py
+   builder: dirhtml
+
+formats: all
+
+python:
+   version: "3.8"
+   install:
+   - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+sphinx-issues

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TheRenegadeCoder/SnakeMD",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "sphinx",
-        "sphinx_rtd_theme",
-        "sphinx-issues"
-    ],
+    install_requires=[],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Right now, we're generating our documentation locally. This is fine, but I find it somewhat cumbersome. I'd like to port everything to Read the Docs (Fixes #43). At the same time, this change will remove the sphinx requirement from setup.py (Fixes #38). Woo!