### PR TITLE
Added Super Linter Action to Lint Markdown

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,55 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,5 +48,6 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,5 +48,5 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,9 +41,6 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
-      - name: Render README
-        run: py snakemd/readme.py
-
       ################################
       # Run Linter against code base #
       ################################

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,11 +15,8 @@ name: Lint Code Base
 # Start the job on all push #
 #############################
 on:
-  push:
-    branches-ignore: [master, main]
-    # Remove the line above to run when pushing to master
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 ###############
 # Set the Job #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,6 +41,9 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
+      - name: Render README
+        run: py snakemd/readme.py
+
       ################################
       # Run Linter against code base #
       ################################

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Welcome to SnakeMD!
+# Welcome to SnakeMD
 
-SnakeMD is your ticket to generating markdown in Python. To prove it to you, we've generated this entire README using SnakeMD. See readme.py for how it was done. To get started, download and install SnakeMD:
+SnakeMD is your ticket to generating Markdown in Python. To prove it to you, we've generated this entire README using SnakeMD. See readme.py for how it was done. To get started, download and install SnakeMD:
 
 ```shell
 pip install snakemd
@@ -10,7 +10,7 @@ In the remainder of this document, we'll show you all of the things this library
 
 ## Table of Contents
 
-Below you'll find the table of contents, but these can also be generated programatically for every markdown document. As of v0.8.0, you can also specify which types of headings are included in the table of contents.
+Below you'll find the table of contents, but these can also be generated programatically for every Markdown document. As of v0.8.0, you can also specify which types of headings are included in the table of contents.
 
 ```py
 def _table_of_contents(doc: Document):
@@ -29,7 +29,7 @@ def _table_of_contents(doc: Document):
 
 ## Paragraphs
 
-Paragraphs are the most basic feature of any markdown file. As a result, they are very easy to create using SnakeMD.
+Paragraphs are the most basic feature of any Markdown file. As a result, they are very easy to create using SnakeMD.
 
 *SnakeMD Source*
 
@@ -95,7 +95,7 @@ def _image(doc: Document):
 
 ## Lists
 
-SnakeMD can make a variety of markdown lists. The two main types of lists are ordered and unordered.
+SnakeMD can make a variety of Markdown lists. The two main types of lists are ordered and unordered.
 
 ### Ordered List
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In the remainder of this document, we'll show you all of the things this library
 
 ## Table of Contents
 
-Below you'll find the table of contents, but these can also be generated programatically for every markdown document.
+Below you'll find the table of contents, but these can also be generated programatically for every markdown document. As of v0.8.0, you can also specify which types of headings are included in the table of contents.
 
 ```py
 def _table_of_contents(doc: Document):

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Below you'll find the table of contents, but these can also be generated program
 
 ```py
 def _table_of_contents(doc: Document):
-    doc.add_table_of_contents()
+    doc.add_table_of_contents(range(2, 4))
 ```
 
 1. [Table of Contents](#table-of-contents)
@@ -22,6 +22,9 @@ def _table_of_contents(doc: Document):
 3. [Links](#links)
 4. [Images](#images)
 5. [Lists](#lists)
+   1. [Ordered List](#ordered-list)
+   2. [Unordered List](#unordered-list)
+   3. [Nested List](#nested-list)
 6. [Tables](#tables)
 7. [Code Blocks](#code-blocks)
 8. [Quotes](#quotes)

--- a/snakemd/readme.py
+++ b/snakemd/readme.py
@@ -134,7 +134,6 @@ def main() -> None:
         _paragraph
     )
 
-
     # Insert Links
     _section(
         doc,

--- a/snakemd/readme.py
+++ b/snakemd/readme.py
@@ -6,7 +6,7 @@ import logging
 def _introduction(doc: Document):
     doc.add_paragraph(
         """
-        SnakeMD is your ticket to generating markdown in Python. 
+        SnakeMD is your ticket to generating Markdown in Python. 
         To prove it to you, we've generated this entire README using SnakeMD.
         See readme.py for how it was done. To get started, download and install SnakeMD:
         """
@@ -107,7 +107,7 @@ def main() -> None:
     doc = Document("README")
 
     # Introduction
-    doc.add_header("Welcome to SnakeMD!")
+    doc.add_header("Welcome to SnakeMD")
     _introduction(doc)
 
     # Table of Contents
@@ -115,7 +115,7 @@ def main() -> None:
     doc.add_paragraph(
         """
         Below you'll find the table of contents, but
-        these can also be generated programatically for every markdown
+        these can also be generated programatically for every Markdown
         document. As of v0.8.0, you can also specify which
         types of headings are included in the table of contents.
         """
@@ -128,7 +128,7 @@ def main() -> None:
         doc,
         "Paragraphs",
         """
-        Paragraphs are the most basic feature of any markdown file. 
+        Paragraphs are the most basic feature of any Markdown file. 
         As a result, they are very easy to create using SnakeMD.
         """,
         _paragraph
@@ -160,7 +160,7 @@ def main() -> None:
     doc.add_header("Lists", level=2)
     doc.add_paragraph(
         """
-        SnakeMD can make a variety of markdown lists. The two main types 
+        SnakeMD can make a variety of Markdown lists. The two main types 
         of lists are ordered and unordered.
         """
     )

--- a/snakemd/readme.py
+++ b/snakemd/readme.py
@@ -23,7 +23,7 @@ def _introduction(doc: Document):
 
 
 def _table_of_contents(doc: Document):
-    doc.add_table_of_contents()
+    doc.add_table_of_contents(range(2, 4))
 
 
 def _ordered_list(doc: Document):

--- a/snakemd/readme.py
+++ b/snakemd/readme.py
@@ -1,4 +1,4 @@
-from snakemd.generator import Document, MDList, Paragraph, InlineText, Table
+from generator import Document, MDList, Paragraph, InlineText, Table
 import inspect
 import logging
 


### PR DESCRIPTION
Added a linter to check the main README when it changes. At the moment, this will only trigger when the main README is regenerated manually. I'm totally sure how I want to handle automated README generation at this point since the linter won't run on it. That said, this is a nice insurance policy for when we do decided to update the README. 