### PR TITLE
Fixed an Issue Where `output_page()` Would Fail Almost Randomly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/settings.json

--- a/docs/version-history.rst
+++ b/docs/version-history.rst
@@ -10,6 +10,9 @@ In an effort to keep history of all the documentation
 for SnakeMD, we've included all old versions below
 as follows:
 
+* v0.10.1
+    * Enforced UTF-8 encoding in the output_page method
+
 * v0.10.0 [:pr:`55`, :pr:`56`, :pr:`57`]
     * Added the CheckBox class for creating checkboxes
     * Added the MDCheckList class for creating lists of checkboxes

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r") as fh:
 
 MAJOR = 0
 MINOR = 10
-PATCH = 0
+PATCH = 1
 
 name = "SnakeMD"
 version = f"{MAJOR}.{MINOR}"

--- a/snakemd/generator.py
+++ b/snakemd/generator.py
@@ -1340,12 +1340,12 @@ class Document:
 
     def output_page(self, dump_dir: str = "") -> None:
         """
-        Generates the markdown file.
+        Generates the markdown file. Assumes UTF-8 encoding.
 
         :param str dump_dir: the path to where you want to dump the file
         """
         pathlib.Path(dump_dir).mkdir(parents=True, exist_ok=True)
-        output_file = open(os.path.join(dump_dir, self._get_file_name()), "w+")
+        output_file = open(os.path.join(dump_dir, self._get_file_name()), "w+", encoding="utf-8")
         output_file.write(str(self))
         output_file.close()
 

--- a/snakemd/generator.py
+++ b/snakemd/generator.py
@@ -1338,14 +1338,15 @@ class Document:
         random.shuffle(self._contents)
         logger.debug(f"Scrambled document")
 
-    def output_page(self, dump_dir: str = "") -> None:
+    def output_page(self, dump_dir: str = "", encoding: str = "utf-8") -> None:
         """
         Generates the markdown file. Assumes UTF-8 encoding.
 
         :param str dump_dir: the path to where you want to dump the file
+        :param str encoding: the encoding to use
         """
         pathlib.Path(dump_dir).mkdir(parents=True, exist_ok=True)
-        output_file = open(os.path.join(dump_dir, self._get_file_name()), "w+", encoding="utf-8")
+        output_file = open(os.path.join(dump_dir, self._get_file_name()), "w+", encoding=encoding)
         output_file.write(str(self))
         output_file.close()
 


### PR DESCRIPTION
This should help as Python strings are Unicode by default. 