### PR TITLE
Removed Separator Code

### DIFF
--- a/snakemd/__init__.py
+++ b/snakemd/__init__.py
@@ -1,6 +1,6 @@
 from .generator import *
 
-def new_doc(name: str = None, separator: str = "-") -> Document:
+def new_doc(name: str = None) -> Document:
     """
     Creates a new SnakeMD document. This is a convenience function
     that allows you to create a new markdown document without having
@@ -21,8 +21,6 @@ def new_doc(name: str = None, separator: str = "-") -> Document:
         .. deprecated:: 0.13.0
             parameter is now optional and will be removed in 1.0.0
             
-    :param str separator: 
-        the whitespace separator; defaults to -
     :return: a new Document object
     """
     if name:
@@ -30,4 +28,4 @@ def new_doc(name: str = None, separator: str = "-") -> Document:
             "name has been deprecated as of 0.13.0", 
             DeprecationWarning
         )
-    return Document(name, separator)
+    return Document(name)

--- a/snakemd/generator.py
+++ b/snakemd/generator.py
@@ -1129,14 +1129,10 @@ class Document:
         
         .. deprecated:: 0.13.0
             parameter is now optional and will be removed in 1.0.0
-
-    :param str separator: 
-        the whitespace separator; defaults to -
     """
 
-    def __init__(self, name: str = None, separator: str = "-") -> None:
+    def __init__(self, name: str = None) -> None:
         self._name: str = name
-        self._separator: str = separator
         self._ext: str = ".md"
         self._contents: list[Element] = list()
         if name:
@@ -1478,7 +1474,7 @@ class Document:
         """
         A helper function for generating the file name.
         """
-        file_name = f"{self._separator.join(self._name.split())}{self._ext}"
+        file_name = f"{'-'.join(self._name.split())}{self._ext}"
         return file_name
     
     def dump(self, name: str, dir: str | os.PathLike = "", ext: str = "md", encoding: str = "utf-8") -> None:


### PR DESCRIPTION
Fixes #79. This was nicely included by #71, but I decided to take a slightly different direction with file output. Now, output is fully customizable through the dump method added in #74. There should be no need to worry about whitespace or separators in file names, since the filename is now totally in control of the user. 