### PR TITLE
Deprecated MDCheckList and Checkbox

### DIFF
--- a/snakemd/generator.py
+++ b/snakemd/generator.py
@@ -143,7 +143,7 @@ class InlineText:
 
         :return: the InlineText object as a string
         """
-        warnings.warn("render has been replaced by __str__ as of 0.14.0")
+        warnings.warn("render has been replaced by __str__ as of 0.14.0", DeprecationWarning)
         return str(self)
 
     def verify_url(self) -> bool:
@@ -330,6 +330,9 @@ class CheckBox(InlineText):
     """
     A checkable box, based of InlineText.
     Supports all formats available via InlineText (eg. url, bold, italics, etc.)
+    
+    .. deprecated:: 0.14.0
+        checkbox features have moved to the MDList object as the checked parameter
 
     :param str text: the inline text to render
     :param str url: the link associated with the inline text
@@ -379,7 +382,7 @@ class CheckBox(InlineText):
 
         :return: the checkbox as a string
         """
-        warnings.warn("render has been replaced by __str__ as of 0.14.0")
+        warnings.warn("render has been replaced by __str__ as of 0.14.0", DeprecationWarning)
         return str(self)
 
 
@@ -413,7 +416,7 @@ class Element:
 
         :return: the element as a markdown string
         """
-        warnings.warn("render has been replaced by __str__ as of 0.14.0")
+        warnings.warn("render has been replaced by __str__ as of 0.14.0", DeprecationWarning)
         return str(self)
 
     def verify(self) -> Verification:

--- a/snakemd/generator.py
+++ b/snakemd/generator.py
@@ -368,8 +368,17 @@ class CheckBox(InlineText):
             image=image
         )
         self.checked = checked
+        warnings.warn(
+            "CheckBox is replaced by the MDList checked parameter", 
+            DeprecationWarning
+        )
         
     def __str__(self) -> str:
+        """
+        Renders the Checkbox.
+
+        :return: the checkbox as a string
+        """
         checked_str = "X" if self.checked else " "
         return f"[{checked_str}] {super().__str__()}"
 
@@ -888,6 +897,9 @@ class MDCheckList(MDList):
     A markdown CheckBox list has boxes that can be clicked.
 
     .. versionadded:: 0.10.0
+    
+    .. deprecated:: 0.14.0
+        MDChecklist has been replaced with preference for the MDList checked parameter
 
     :param Iterable[str | InlineText | Paragraph | MDList] items:
         a "list" of objects to be rendered as a Checkbox list
@@ -898,6 +910,10 @@ class MDCheckList(MDList):
     def __init__(self,  items: Iterable[str | InlineText | Paragraph | MDList], checked: bool = False) -> None:
         super().__init__(items, False)
         self.checked = checked
+        warnings.warn(
+            "MDChecklist is replaced by the MDList checked parameter", 
+            DeprecationWarning
+        )
         
     def __str__(self) -> str:
         """

--- a/snakemd/generator.py
+++ b/snakemd/generator.py
@@ -780,12 +780,20 @@ class MDList(Element):
         a "list" of objects to be rendered as a list
     :param bool ordered: the ordered state of the list;
         set to True to render an ordered list (i.e., True -> 1. item)
+    :param None | bool | Iterable[bool] checked: the checked state of the list;
+        set to True, False, or an iterable of booleans to enable the checklist feature.
     """
 
-    def __init__(self, items: Iterable[str | InlineText | Paragraph | MDList], ordered: bool = False) -> None:
+    def __init__(
+        self, 
+        items: Iterable[str | InlineText | Paragraph | MDList], 
+        ordered: bool = False, 
+        checked: None | bool | Iterable[bool] = None
+    ) -> None:
         super().__init__()
         self._items: MDList | Paragraph = self._process_items(items)
         self._ordered = ordered
+        self._checked = checked
         self._space = ""
         
     def __str__(self) -> str:
@@ -803,10 +811,23 @@ class MDList(Element):
                 item._space = self._space + " " * self._get_indent_size(i)
                 output.append(str(item))
             else:
+                # Create the start of the row based on `order` parameter
                 if self._ordered:
-                    output.append(f"{self._space}{i}. {item}")
+                    row = f"{self._space}{i}."
                 else:
-                    output.append(f"{self._space}- {item}")
+                    row = f"{self._space}-"
+                    
+                # Add checkbox based on `checked` parameter
+                if isinstance(self._checked, bool):
+                    checked_str = "X" if self._checked else " "
+                    row = f"{row} [{checked_str}] {item}"
+                elif self._checked is not None:
+                    checked_str = "X" if self._checked[i - 1] else " "
+                    row = f"{row} [{checked_str}] {item}"
+                else:    
+                    row = f"{row} {item}"
+                    
+                output.append(row)
                 i += 1
         return "\n".join(output)
 

--- a/tests/test_md_list.py
+++ b/tests/test_md_list.py
@@ -66,3 +66,56 @@ def test_md_list_nested_ordered():
 def test_md_list_checkboxes():
     md_list = MDList([CheckBox("Deku"), CheckBox("Bakugo", checked=True), CheckBox("Uraraka")], ordered=False)
     assert str(md_list) == "- [ ] Deku\n- [X] Bakugo\n- [ ] Uraraka"
+
+
+def test_md_list_one_str_unchecked():
+    md_list = MDList(["Deku"], checked=False)
+    assert str(md_list) == "- [ ] Deku"
+
+
+def test_md_list_one_paragraph_unchecked():
+    md_list = MDList([Paragraph(["Deku"])], checked=False)
+    assert str(md_list) == "- [ ] Deku"
+
+
+def test_md_list_many_unchecked():
+    md_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=False)
+    assert str(md_list) == "- [ ] Deku\n- [ ] Bakugo\n- [ ] Uraraka"
+
+
+def test_md_list_many_mixed_syntax_unchecked():
+    md_list = MDList(["Deku", "Bakugo", Paragraph(["Uraraka"])], checked=False)
+    assert str(md_list) == "- [ ] Deku\n- [ ] Bakugo\n- [ ] Uraraka"
+
+
+def test_md_list_many_checked():
+    md_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=True)
+    assert str(md_list) == "- [X] Deku\n- [X] Bakugo\n- [X] Uraraka"
+
+
+def test_md_list_nested_unchecked():
+    inner_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=False)
+    outer_list = MDList(["Characters", inner_list, "Powers"], checked=False)
+    assert str(outer_list) == "- [ ] Characters\n  - [ ] Deku\n  - [ ] Bakugo\n  - [ ] Uraraka\n- [ ] Powers"
+
+
+def test_md_list_nested_checked():
+    inner_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=True)
+    outer_list = MDList(["Characters", inner_list, "Powers"], checked=True)
+    assert str(outer_list) == "- [X] Characters\n  - [X] Deku\n  - [X] Bakugo\n  - [X] Uraraka\n- [X] Powers"
+    
+    
+def test_md_list_many_checked_iterable():
+    md_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=[True, True, True])
+    assert str(md_list) == "- [X] Deku\n- [X] Bakugo\n- [X] Uraraka"
+
+
+def test_md_list_many_checked_iterable_mixed():
+    md_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=[True, False, True])
+    assert str(md_list) == "- [X] Deku\n- [ ] Bakugo\n- [X] Uraraka"
+    
+
+def test_md_list_nested_checked_iterable_mixed():
+    inner_list = MDList(["Deku", "Bakugo", "Uraraka"], checked=[True, True, False])
+    outer_list = MDList(["Characters", inner_list, "Powers"], checked=[False, True])
+    assert str(outer_list) == "- [ ] Characters\n  - [X] Deku\n  - [X] Bakugo\n  - [ ] Uraraka\n- [X] Powers"


### PR DESCRIPTION
These are nice features, but they didn't really fit the overall structure I was going for in the original design. I'm not against the idea of having these special case inherited components, but I find having a single InlineText and a single MDList object as preferable to a more complex hierarchy. 

Also, I never really liked the CheckBox as an InlineText object. It's not like the object can be used in other places outside of lists, so it seemed weird to use it like one. 

Fixes #85 