### PR TITLE
Incorporated More Precise Language Throughout Docs as Well as Doctests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: PyTest
+name: PyTest & Doctest
 
 on:
   pull_request:
@@ -30,3 +30,8 @@ jobs:
 
     - name: Coverage
       run: coverage report
+
+    - name: Doctest
+      run: |
+        cd docs
+        make doctest    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r docs/requirements.txt
 
     - name: PyTest
       run: coverage run --source=snakemd -m pytest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,12 @@ author = 'The Renegade Coder'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', "sphinx_issues", 'sphinx.ext.intersphinx']
+extensions = [
+    'sphinx.ext.autodoc', 
+    'sphinx_issues', 
+    'sphinx.ext.intersphinx', 
+    'sphinx.ext.doctest'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/docs/element-api.rst
+++ b/docs/docs/element-api.rst
@@ -31,11 +31,11 @@ custom blocks using the :func:`snakemd.Document.add_block` method. To make use
 of this method, blocks must be imported and constructed manually,
 like the following :class:`snakemd.Heading` example:
 
-.. code-block:: python 
+.. doctest:: block
 
-   from snakemd import Heading, new_doc
-   doc = new_doc()
-   doc.add_block(Heading("Hello, World!", 2))
+   >>> from snakemd import Heading, new_doc
+   >>> doc = new_doc()
+   >>> heading = doc.add_block(Heading("Hello, World!", 2))
 
 The remainder of this section introduces the Block interface
 as well as all of the Blocks currently available for use. 
@@ -135,11 +135,11 @@ the returned Heading object has no support for linking. However,
 with Inline elements, we can create a custom Heading to our
 standards:
 
-.. code-block:: python 
+.. doctest:: inline
 
-   from snakemd import Heading, Inline, new_doc
-   doc = new_doc()    
-   doc.add_block(Heading(Inline("Hello, World!", "https://snakemd.io"), 2))
+   >>> from snakemd import Heading, Inline, new_doc
+   >>> doc = new_doc()    
+   >>> heading = doc.add_block(Heading(Inline("Hello, World!", "https://snakemd.io"), 2))
 
 The remainder of this section introduces the Inline class.
 

--- a/docs/docs/element-api.rst
+++ b/docs/docs/element-api.rst
@@ -17,6 +17,16 @@ is known as an element. Below is the element interface.
    :show-inheritance:
    :special-members: __str__
 
+For consistency, element mutators all return self to allow
+for method chaining. This is sometimes referred to as the
+fluent interface pattern, and it's particularly useful
+for applying a series of changes to a single element. This
+design choice most obviously shines in both :class:`snakemd.Paragraph`, 
+which allows different aspects of the text to be replaced
+over a series of chained methods, and :class:`snakemd.Inline`,
+which allows inline elements to be styled over a series of
+chained methods. 
+
 For practical purposes, elements cannot be constructed directly.
 Instead, they are broken down into two main categories:
 block and inline. 

--- a/docs/docs/element-api.rst
+++ b/docs/docs/element-api.rst
@@ -150,3 +150,4 @@ Inline
    :members:
    :undoc-members:
    :show-inheritance:
+   :special-members: __str__

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -9,11 +9,11 @@ date, with the most recently published resources first.
 v2.x
 ----
 
-- TBD
+* **2023-04-14**: `How to Migrate to SnakeMD 2.0.0 <https://therenegadecoder.com/code/how-to-migrate-to-snakemd-2-0-0/>`_
+* **2022-05-13**: `The Complete Guide to SnakeMD: A Python Library for Generating Markdown <https://therenegadecoder.com/code/the-complete-guide-to-snakemd-a-python-library-for-generating-markdown/>`_
 
 v0.x
 ----
 
-* **2022-05-13**: `The Complete Guide to SnakeMD: A Python Library for Generating Markdown <https://therenegadecoder.com/code/the-complete-guide-to-snakemd-a-python-library-for-generating-markdown/>`_
 * **2022-01-22**: `SnakeMD 0.10.x Features Checklists <https://therenegadecoder.com/meta/snakemd-0-10-x-features-checklists/>`_
-* **2021-09-24**: `How to Generate Markdown in Python Using SnakeMD <https://therenegadecoder.com/code/how-to-generate-markdown-in-python-using-snakemd/>`_
+* **2021-09-24**: `How to Generate Markdown in Python Using SnakeMD v0.x <https://therenegadecoder.com/code/how-to-generate-markdown-in-python-using-snakemd/>`_

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,11 @@ with open("README.md", "r") as fh:
 MAJOR = 2
 MINOR = 0
 PATCH = 0
+PRE = "b2"
 
 name = "SnakeMD"
 version = f"{MAJOR}.{MINOR}"
-release = f"{MAJOR}.{MINOR}.{PATCH}b1"
+release = f"{MAJOR}.{MINOR}.{PATCH}{PRE}"
 setuptools.setup(
     name=name,
     version=release,

--- a/snakemd/__init__.py
+++ b/snakemd/__init__.py
@@ -9,10 +9,10 @@ def new_doc() -> Document:
     wants to take advantage of the procedural interface of SnakeMD.
     For those looking for a bit more control, each element class
     will need to be imported as needed.
-
-    .. code-block:: Python
-
-        doc = snakemd.new_doc()
+    
+    .. doctest:: document
+        
+        >>> doc = snakemd.new_doc()
 
     :return: 
         a new Document object

--- a/snakemd/document.py
+++ b/snakemd/document.py
@@ -135,10 +135,13 @@ class Document:
     def add_ordered_list(self, items: Iterable[str]) -> MDList:
         """
         A convenience method which adds an ordered list to the document:
-
-        .. code-block:: Python
-
-            doc.add_ordered_list(["Goku", "Piccolo", "Vegeta"])
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_ordered_list(["Goku", "Piccolo", "Vegeta"])
+            >>> str(doc)
+            '1. Goku\\n2. Piccolo\\n3. Vegeta'
 
         :param Iterable[str] items: 
             a "list" of strings

--- a/snakemd/document.py
+++ b/snakemd/document.py
@@ -26,6 +26,11 @@ class Document:
     .. testsetup:: document
     
         import snakemd
+        
+    .. testcleanup:: document
+    
+        import os
+        os.remove("README.md")
     """
 
     def __init__(self) -> None:
@@ -260,10 +265,13 @@ class Document:
     def add_quote(self, text: str) -> Quote:
         """
         A convenience method which adds a blockquote to the document:
-
-        .. code-block:: Python
-
-            doc.add_quote("Welcome to the Internet!")
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_quote("Welcome to the Internet!")
+            >>> str(doc)
+            '> Welcome to the Internet!'
 
         :param str text: 
             the text to be quoted
@@ -278,10 +286,13 @@ class Document:
     def add_horizontal_rule(self) -> HorizontalRule:
         """
         A convenience method which adds a horizontal rule to the document:
-
-        .. code-block:: Python
-
-            doc.add_horizontal_rule()
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_horizontal_rule()
+            >>> str(doc)
+            '***'
 
         :return: 
             the :class:`HorizontalRule` added to this Document
@@ -298,10 +309,15 @@ class Document:
         document. The table itself is lazy loaded, so it always captures
         all of the heading blocks regardless of where the table of contents
         is added to the document.
-
-        .. code-block:: Python
-
-            doc.add_table_of_contents()
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_table_of_contents()
+            >>> _ = doc.add_heading("First Item", 2)
+            >>> _ = doc.add_heading("Second Item", 2) 
+            >>> str(doc)
+            '1. [First Item](#first-item)\\n2. [Second Item](#second-item)\\n\\n## First Item\\n\\n## Second Item'
 
         :param range levels: 
             a range of heading levels to be included in the table of contents
@@ -319,10 +335,14 @@ class Document:
         """
         A silly method which mixes all of the blocks in this document in
         a random order.
-
-        .. code-block:: Python
-
-            doc.scramble()
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_horizontal_rule()
+            >>> doc.scramble()
+            >>> str(doc)
+            '***'
         """
         random.shuffle(self._contents)
         logger.debug(f"Scrambled document")
@@ -334,10 +354,12 @@ class Document:
         made if it does not already exist. This method also assumes a file extension of md
         and a file encoding of utf-8, all of which are configurable through the method
         parameters.
-
-        .. code-block:: Python
-
-            doc.dump("README")
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_horizontal_rule()
+            >>> doc.dump("README")
 
         :param str name: 
             the name of the markdown file to output without the file extension

--- a/snakemd/document.py
+++ b/snakemd/document.py
@@ -148,7 +148,7 @@ class Document:
         :return: 
             the :class:`MDList` added to this Document
         """
-        md_list = MDList([Inline(item) for item in items], ordered=True)
+        md_list = MDList(items, ordered=True)
         self._contents.append(md_list)
         logger.debug(f"Added ordered list to document\n{md_list}")
         return md_list
@@ -156,17 +156,20 @@ class Document:
     def add_unordered_list(self, items: Iterable[str]) -> MDList:
         """
         A convenience method which adds an unordered list to the document.
-
-        .. code-block:: Python
-
-            doc.add_unordered_list(["Deku", "Bakugo", "Kirishima"])
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_unordered_list(["Deku", "Bakugo", "Kirishima"])
+            >>> str(doc)
+            '- Deku\\n- Bakugo\\n- Kirishima'
 
         :param Iterable[str] items: 
             a "list" of strings
         :return: 
             the :class:`MDList` added to this Document
         """
-        md_list = MDList([Inline(item) for item in items])
+        md_list = MDList(items)
         self._contents.append(md_list)
         logger.debug(f"Added unordered list to document\n{md_list}")
         return md_list
@@ -174,17 +177,20 @@ class Document:
     def add_checklist(self, items: Iterable[str]) -> MDList:
         """
         A convenience method which adds a checklist to the document.
-
-        .. code-block:: Python
-
-            doc.add_checklist(["Okabe", "Mayuri", "Kurisu"])
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_checklist(["Okabe", "Mayuri", "Kurisu"])
+            >>> str(doc)
+            '- [ ] Okabe\\n- [ ] Mayuri\\n- [ ] Kurisu'
 
         :param Iterable[str] items: 
             a "list" of strings
         :return: 
             the :class:`MDList` added to this Document
         """
-        md_checklist = MDList([Inline(item) for item in items], checked=False)
+        md_checklist = MDList(items, checked=False)
         self._contents.append(md_checklist)
         logger.debug(f"Added checklist to document\n{md_checklist}")
         return md_checklist
@@ -198,18 +204,16 @@ class Document:
     ) -> Table:
         """
         A convenience method which adds a table to the document:
-
-        .. code-block:: Python
-
-            doc.add_table(
-                ["Place", "Name"],
-                [
-                    ["1st", "Robert"],
-                    ["2nd", "Rae"]
-                ],
-                [snakemd.Table.Align.CENTER, snakemd.Table.Align.RIGHT],
-                0
-            )
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> header = ["Place", "Name"]
+            >>> rows = [["1st", "Robert"], ["2nd", "Rae"]]
+            >>> align = [snakemd.Table.Align.CENTER, snakemd.Table.Align.RIGHT]
+            >>> _ = doc.add_table(header, rows, align=align)
+            >>> str(doc)
+            '| Place | Name   |\\n| :---: | -----: |\\n| 1st   | Robert |\\n| 2nd   | Rae    |'
 
         :param Iterable[str] header: 
             a "list" of strings

--- a/snakemd/document.py
+++ b/snakemd/document.py
@@ -23,14 +23,9 @@ class Document:
     take advantage of the :func:`add_block` function to provide
     custom markdown blocks.
 
-    All methods described in the Document class include sample
-    code. Sample code assumes a generic :code:`doc` object exists,
-    which can be created as follows:
-
-    .. code-block:: Python
-
+    .. testsetup:: document
+    
         import snakemd
-        doc = snakemd.new_doc()
     """
 
     def __init__(self) -> None:
@@ -51,10 +46,13 @@ class Document:
         A generic function for appending blocks to the document.
         Use this function when you want a little more control over
         what the output looks like.
-
-        .. code-block:: Python
-
-            doc.add_block(Heading("Python is Cool!", 2))
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_block(snakemd.Heading("Python is Cool!", 2)) 
+            >>> str(doc)
+            '## Python is Cool!'
 
         :param Block block: 
             a markdown block (e.g., Table, Heading, etc.)
@@ -68,10 +66,13 @@ class Document:
     def add_raw(self, text: str) -> Raw:
         """
         A convenience method which adds text as-is to the document:
-
-        .. code-block:: Python
-
-            doc.add_raw("X: 5\\nY: 4\\nZ: 3")
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_raw("X: 5\\nY: 4\\nZ: 3")
+            >>> str(doc)
+            'X: 5\\nY: 4\\nZ: 3'
 
         :param str text: 
             some text 
@@ -86,6 +87,13 @@ class Document:
     def add_heading(self, text: str, level: int = 1) -> Heading:
         """
         A convenience method which adds a heading to the document:
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_heading("Welcome to SnakeMD!")
+            >>> str(doc)
+            '# Welcome to SnakeMD!'
 
         .. code-block:: Python
 
@@ -106,10 +114,13 @@ class Document:
     def add_paragraph(self, text: str) -> Paragraph:
         """
         A convenience method which adds a paragraph of text to the document:
-
-        .. code-block:: Python
-
-            doc.add_paragraph("Mitochondria is the powerhouse of the cell.")
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_paragraph("Mitochondria is the powerhouse of the cell.")
+            >>> str(doc)
+            'Mitochondria is the powerhouse of the cell.'
 
         :param str text: 
             any arbitrary text

--- a/snakemd/document.py
+++ b/snakemd/document.py
@@ -237,10 +237,13 @@ class Document:
     def add_code(self, code: str, lang: str = "generic") -> Code:
         """
         A convenience method which adds a code block to the document:
-
-        .. code-block:: Python
-
-            doc.add_code("x = 5")
+        
+        .. doctest:: document
+        
+            >>> doc = snakemd.new_doc()
+            >>> _ = doc.add_code("x = 5")
+            >>> str(doc)
+            '```generic\\nx = 5\\n```'
 
         :param str code: 
             a preformatted code string

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -49,26 +49,35 @@ class Inline(Element):
         the inline text to render
     :param None | str image: 
         the source (either url or path) associated with an image
+        
+        - defaults to :code:`None`
+        - set to a string representing a URL or path to render an image (i.e., :code:`![text](image)`)
     :param None | str link: 
         the link (either url or path) associated with the inline element
+        
+        - defaults to :code:`None`
+        - set to a string representing a URL or path to render a link (i.e., :code:`[text](link)`)
     :param bool bold: 
         the bold state of the inline text
         
         - defaults to :code:`False`
-        - set to :code:`True` to render bold inline text (i.e., :code:`**bold**`)
+        - set to :code:`True` to render bold text (i.e., :code:`**text**`)
     :param bool italics: 
         the italics state of the inline element
         
         - defaults to :code:`False`
-        - set to :code:`True` to render inline text in italics (i.e., :code:`_italics_`)
+        - set to :code:`True` to render text in italics (i.e., :code:`_text_`)
     :param bool strikethrough: 
         the strikethrough state of the inline text
         
         - defaults to :code:`False`
-        - set to :code:`True` to render inline text with a strikethrough (i.e., :code:`~~strikethrough~~`)
+        - set to :code:`True` to render text with a strikethrough 
+          (i.e., :code:`~~text~~`)
     :param bool code: 
-        the italics state of the inline text;
-        set to True to render inline text as code (i.e., True -> `code`)
+        the code state of the inline text
+        
+        - defaults to :code:`False`
+        - set to :code:`True` to render text as code (i.e., :code:`\`text\``)
     """
 
     def __init__(

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -36,14 +36,9 @@ class Inline(Element):
     If styled code is necessary, it's possible to render the inline element
     as a string and pass the result to another inline element. 
 
-    All methods described in the Inline class include sample
-    code. Sample code assumes a generic :code:`inline` object exists,
-    which can be created as follows:
-
-    .. doctest:: Python
-
-        >>> from snakemd import Inline
-        >>> inline = Inline("Sample Text")
+    .. testsetup:: inline
+    
+        from snakemd import Inline
 
     :param str text: 
         the inline text to render
@@ -128,9 +123,11 @@ class Inline(Element):
         Checks if this Inline element is a text-only element. If not, it must
         be an image, a link, or a code snippet.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            is_inline_text: bool = inline.is_text()
+            >>> inline = Inline("This is text")
+            >>> inline.is_text()
+            True
 
         :return: 
             True if this is a text-only element; False otherwise

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -549,7 +549,7 @@ class MDList(Block):
     A markdown list is a standalone list that comes in three varieties: ordered, unordered, and checked.
 
     :raises ValueError: 
-        when the checked parameter is provided an Iterable[bool] that does not 
+        when the checked argument is an Iterable[bool] that does not 
         match the number of top-level elements in the list
     :param Iterable[str | Inline | Block] items:
         a "list" of objects to be rendered as a list
@@ -699,10 +699,15 @@ class Paragraph(Block):
         from snakemd import Paragraph
 
     :param str | Iterable[Inline | str] content: 
-        a single string or a "list" of text objects to render as a paragraph        
+        the text to be rendered as a paragraph where whitespace is not respected
+        (see :class:`snakemd.Raw` for whitespace sensitive applications)
+        
+        - set to a string for a single line of unformatted text
+        - set to a "list" of text objects for a single line of
+          custom formatted text     
     """
 
-    def __init__(self, content: str | Iterable[Inline | str]):
+    def __init__(self, content: str | Iterable[str | Inline]):
         super().__init__()
         self._content: list[Inline] = self._process_content(content)
 
@@ -892,8 +897,11 @@ class Quote(Block):
     A quote is a standalone block of emphasized text. Quotes can be
     nested and can contain other blocks. 
 
-    :param str | Iterable[str | Inline | Block] lines: 
-        a single string or a "list" of text objects to be formatted as a quote
+    :param str | Iterable[str | Inline | Block] lines:
+        the text to be formatted as a Markdown quote
+         
+        - set to a string where whitespace is respected (similar to :class:`snakemd.Code`)
+        - set to a "list" of text objects which serve as individual lines of a quote
     """
 
     def __init__(self, lines: str | Iterable[str | Inline | Block]) -> None:

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -500,14 +500,14 @@ class MDList(Block):
     :param bool ordered: 
         the ordered state of the list
         
-        - defaults to :code:`False` which renders an unordered list
-        - set to :code:`True` to render an ordered list
+        - defaults to :code:`False` which renders an unordered list (i.e., :code:`-`)
+        - set to :code:`True` to render an ordered list (i.e., :code:`1.`)
     :param None | bool | Iterable[bool] checked: 
         the checked state of the list
         
         - defaults to :code:`None` which excludes checkboxes from being rendered
-        - set to :code:`False` for a series of unchecked boxes (e.g., :code:`- [ ]`)
-        - set to :code:`True` for a series of checked boxes (e.g., :code:`- [x]`)
+        - set to :code:`False` for a series of unchecked boxes (i.e., :code:`- [ ]`)
+        - set to :code:`True` for a series of checked boxes (i.e., :code:`- [x]`)
         - set to :code:`Iterable[bool]` to configure the checked 
           status of the top-level list elements directly
     """

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -484,25 +484,35 @@ class Heading(Block):
             self._level -= 1
         return self
 
-    def demote(self) -> None:
+    def demote(self) -> Heading:
         """
         Demotes a heading down a level. Fails silently if
         the heading is already at the lowest level (i.e., :code:`<h6>`).
 
-        .. code-block:: Python
+        .. doctest:: heading
 
-            heading.demote()
+            >>> heading = Heading("This is an H2 heading", 1).demote()
+            >>> str(heading)
+            '## This is an H2 heading'
+            
+        :return:
+            self
         """
         if self._level < 6:
             self._level += 1
+        return self
 
     def get_text(self) -> str:
         """
-        Returns the heading text free of any styling.
+        Returns the heading text free of any styling. Useful
+        when the heading is composed of various Inline elements,
+        and the raw text is needed without styling or linking.
 
-        .. code-block:: Python
+        .. doctest:: heading
 
-            text: str = heading.get_text()
+            >>> heading = Heading("This is the heading text", 1)
+            >>> heading.get_text()
+            'This is the heading text'
 
         :return: 
             the heading as a string

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -693,15 +693,10 @@ class MDList(Block):
 class Paragraph(Block):
     """
     A paragraph is a standalone block of text. 
-
-    All methods described in the Paragraph class include sample
-    code. Sample code assumes a generic :code:`paragraph` object exists,
-    which can be created as follows:
-
-    .. code-block:: python
-
+    
+    .. testsetup:: paragraph
+    
         from snakemd import Paragraph
-        paragraph = Paragraph("Hello, World!")
 
     :param str | Iterable[Inline | str] content: 
         a single string or a "list" of text objects to render as a paragraph        
@@ -749,20 +744,25 @@ class Paragraph(Block):
         paragraph = ''.join(str(item) for item in self._content)
         return " ".join(paragraph.split())
 
-    def add(self, text: Inline | str) -> None:
+    def add(self, text: str | Inline) -> Paragraph:
         """
         Adds a text object to the paragraph.
+        
+        .. doctest:: paragraph
+        
+            >>> paragraph = Paragraph("Hello! ").add("I come in peace")
+            >>> str(paragraph)
+            'Hello! I come in peace'
 
-        .. code-block:: Python
-
-            paragraph.add("I come in peace")
-
-        :param Inline | str text: 
+        :param str | Inline text: 
             a custom Inline element
+        :return:
+            self
         """
         if isinstance(text, str):
             text = Inline(text)
         self._content.append(text)
+        return self
 
     def _replace_any(self, target: str, text: Inline, count: int = -1) -> Paragraph:
         """
@@ -809,23 +809,25 @@ class Paragraph(Block):
         the users choice. Like :meth:`insert_link`, this method is modeled after
         :py:meth:`str.replace` of the standard library. As a result, a count
         can be provided to limit the number of strings replaced in the paragraph.
-
-        .. code-block:: Python
-
-            paragraph.replace("Here", "There")
+        
+        .. doctest:: paragraph
+        
+            >>> paragraph = Paragraph("I come in piece").replace("piece", "peace")
+            >>> str(paragraph)
+            'I come in peace'
 
         :param str target: 
             the target string to replace
         :param str replacement: 
             the Inline object to insert in place of the target
         :param int count: 
-            the number of links to insert; defaults to -1
+            the number of targets to replace; defaults to -1 (all)
         :return: 
             self
         """
         return self._replace_any(target, Inline(replacement), count)
 
-    def insert_link(self, target: str, url: str, count: int = -1) -> Paragraph:
+    def insert_link(self, target: str, link: str, count: int = -1) -> Paragraph:
         """
         A convenience method which inserts links in the paragraph
         for all matching instances of a target string. This method
@@ -833,21 +835,23 @@ class Paragraph(Block):
         provided to limit the number of insertions. This method
         will not replace links of text that have already been linked.
         See :meth:`snakemd.Paragraph.replace_link` for that behavior.
-
-        .. code-block:: Python
-
-            paragraph.insert_link("Here", "https://therenegadecoder.com")
+        
+        .. doctest:: paragraph
+        
+            >>> paragraph = Paragraph("Go here for docs").insert_link("here", "https://snakemd.io")
+            >>> str(paragraph)
+            'Go [here](https://snakemd.io) for docs'
 
         :param str target: 
             the string to link
-        :param str url: 
-            the url to link
+        :param str link: 
+            the url or path
         :param int count: 
             the number of links to insert; defaults to -1 (all)
         :return: 
             self
         """
-        return self._replace_any(target, Inline(target, link=url), count)
+        return self._replace_any(target, Inline(target, link=link), count)
 
     def replace_link(self, target_link: str, replacement_link: str, count: int = -1) -> Paragraph:
         """
@@ -857,10 +861,14 @@ class Paragraph(Block):
         the number of links replaced in the paragraph. This method is useful
         if you want to replace existing URLs but don't necessarily care what
         the anchor text is.
-
-        .. code-block:: Python
-
-            paragraph.replace_link("https://stackoverflow.com", "https://therenegadecoder.com")
+        
+        .. doctest:: paragraph
+        
+            >>> old = "https://therenegadecoder.com"
+            >>> new = "https://snakemd.io"
+            >>> paragraph = Paragraph("Go here for docs").insert_link("here", old).replace_link(old, new) 
+            >>> str(paragraph)
+            'Go [here](https://snakemd.io) for docs'
 
         :param str target_link: 
             the link to replace

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -523,6 +523,8 @@ class MDList(Block):
         self._ordered = ordered
         self._checked = checked
         self._space = ""
+        if isinstance(self._checked, list) and self._top_level_count() != len(self._checked):
+            raise ValueError(f"Number of top-level elements in checklist does not match number of booleans supplied by checked parameter: {self._checked}")
 
     def __str__(self) -> str:
         """
@@ -593,6 +595,23 @@ class MDList(Block):
             else:
                 processed.append(item)
         return processed
+    
+    def _top_level_count(self) -> int:
+        """
+        Given that MDList can accept a variety of blocks,
+        we need to know how many items in the provided list
+        are top-level elements (i.e., not nested list elements).
+        We use this number to throw errors if this count does
+        not match up with the checklist count.
+
+        :return: 
+            a count of top-level elements
+        """
+        count = 0
+        for item in self._items:
+            if not isinstance(item, MDList):
+                count += 1
+        return count
 
     def _get_indent_size(self, item_index: int = -1) -> int:
         """

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -1164,7 +1164,8 @@ class Table(Block):
         
         .. doctest:: table
         
-            >>> table = Table(["Rank", "Player"], [["1st", "Crosby"], ["2nd", "McDavid"]]).add_row(["3rd", "Matthews"])
+            >>> table = Table(["Rank", "Player"], [["1st", "Crosby"], ["2nd", "McDavid"]])
+            >>> _ = table.add_row(["3rd", "Matthews"])
             >>> str(table)
             '| Rank | Player   |\\n| ---- | -------- |\\n| 1st  | Crosby   |\\n| 2nd  | McDavid  |\\n| 3rd  | Matthews |'
 
@@ -1189,7 +1190,7 @@ class Table(Block):
         # Add it to table
         self._body.append(row_list)
         
-        # Updating widths as needed
+        # Update widths as needed
         for i, item in enumerate(row_list):
             item_width = len(str(item))
             if item_width > self._widths[i]:

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -40,10 +40,10 @@ class Inline(Element):
     code. Sample code assumes a generic :code:`inline` object exists,
     which can be created as follows:
 
-    .. code-block:: Python
+    .. doctest:: Python
 
-        from snakemd import Inline
-        inline = Inline("Sample Text")
+        >>> from snakemd import Inline
+        >>> inline = Inline("Sample Text")
 
     :param str text: 
         the inline text to render

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -495,6 +495,9 @@ class MDList(Block):
     """
     A markdown list is a standalone list that comes in three varieties: ordered, unordered, and checked.
 
+    :raises ValueError: 
+        when the checked parameter is provided an Iterable[bool] that does not 
+        match the number of top-level elements in the list
     :param Iterable[str | Inline | Block] items:
         a "list" of objects to be rendered as a list
     :param bool ordered: 
@@ -520,7 +523,7 @@ class MDList(Block):
     ) -> None:
         super().__init__()
         self._items: list[Block] = self._process_items(items)
-        self._ordered = ordered
+        self._ordered: bool = ordered
         self._checked = checked
         self._space = ""
         if isinstance(self._checked, list) and self._top_level_count() != len(self._checked):

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -96,8 +96,14 @@ class Inline(Element):
     def __str__(self) -> str:
         """
         Renders self as a string. In this case,
-        inline text can represent many different types of data from
-        stylized text to inline code to links and images.
+        inline can represent many different types of data from
+        stylized text to code, links, and images.
+        
+        .. doctest:: inline
+
+            >>> inline = Inline("This is text", bold=True, italics=True)
+            >>> str(inline)
+            '_**This is text**_'
 
         :return: 
             the Inline object as a string

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -159,9 +159,11 @@ class Inline(Element):
         """
         Adds bold styling to self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.bold()
+            >>> inline = Inline("This is bold text").bold()
+            >>> str(inline)
+            '**This is bold text**'
 
         :return: 
             self
@@ -173,9 +175,11 @@ class Inline(Element):
         """
         Removes bold styling from self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.unbold()
+            >>> inline = Inline("This is normal text", bold=True).unbold()
+            >>> str(inline)
+            'This is normal text'
 
         :return: 
             self
@@ -187,9 +191,11 @@ class Inline(Element):
         """
         Adds italics styling to self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.italicize()
+            >>> inline = Inline("This is italicized text").italicize()
+            >>> str(inline)
+            '_This is italicized text_'
 
         :return: 
             self
@@ -201,9 +207,11 @@ class Inline(Element):
         """
         Removes italics styling from self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.unitalicize()
+            >>> inline = Inline("This is normal text", italics=True).unitalicize()
+            >>> str(inline)
+            'This is normal text'
 
         :return: 
             self

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -355,6 +355,14 @@ class Code(Block):
     A code block is a standalone block of syntax-highlighted code.
     Code blocks can have generic highlighting or highlighting based
     on their language. 
+    
+    :param str | Code code:
+        the sourcecode to format as a Markdown code block
+        
+        - set to a string which represented preformatted code (i.e., whitespace is respected)
+        - set to a Code object to nest an existing code block
+    :param str lang:
+        the programming language for the code block; defaults to 'generic'
     """
 
     def __init__(self, code: str | Code, lang: str = "generic"):
@@ -897,16 +905,16 @@ class Quote(Block):
     A quote is a standalone block of emphasized text. Quotes can be
     nested and can contain other blocks. 
 
-    :param str | Iterable[str | Inline | Block] lines:
+    :param str | Iterable[str | Inline | Block] content:
         the text to be formatted as a Markdown quote
          
         - set to a string where whitespace is respected (similar to :class:`snakemd.Code`)
         - set to a "list" of text objects which serve as individual lines of a quote
     """
 
-    def __init__(self, lines: str | Iterable[str | Inline | Block]) -> None:
+    def __init__(self, content: str | Iterable[str | Inline | Block]) -> None:
         super().__init__()
-        self._lines: list[Block] = self._process_content(lines)
+        self._lines: list[Block] = self._process_content(content)
         self._depth = 1
 
     @staticmethod

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -498,11 +498,18 @@ class MDList(Block):
     :param Iterable[str | Inline | Block] items:
         a "list" of objects to be rendered as a list
     :param bool ordered: 
-        the ordered state of the list;
-        set to True to render an ordered list (i.e., True -> 1. item)
+        the ordered state of the list
+        
+        - defaults to :code:`False` which renders an unordered list
+        - set to :code:`True` to render an ordered list
     :param None | bool | Iterable[bool] checked: 
-        the checked state of the list;
-        set to True, False, or an iterable of booleans to enable the checklist feature.
+        the checked state of the list
+        
+        - defaults to :code:`None` which excludes checkboxes from being rendered
+        - set to :code:`False` for a series of unchecked boxes (e.g., :code:`- [ ]`)
+        - set to :code:`True` for a series of checked boxes (e.g., :code:`- [x]`)
+        - set to :code:`Iterable[bool]` to configure the checked 
+          status of the top-level list elements directly
     """
 
     def __init__(

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -223,9 +223,11 @@ class Inline(Element):
         """
         Adds strikethrough styling to self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.strikethrough()
+            >>> inline = Inline("This is striked text").strikethrough()
+            >>> str(inline)
+            '~~This is striked text~~'
 
         :return: 
             self
@@ -237,9 +239,11 @@ class Inline(Element):
         """
         Remove strikethrough styling from self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.unstrikethrough()
+            >>> inline = Inline("This is normal text", strikethrough=True).unstrikethrough()
+            >>> str(inline)
+            'This is normal text'
 
         :return: 
             self

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -255,9 +255,11 @@ class Inline(Element):
         """
         Adds code style to self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.code()
+            >>> inline = Inline("x = 5").code()
+            >>> str(inline)
+            '`x = 5`'
 
         :return: 
             self
@@ -269,9 +271,11 @@ class Inline(Element):
         """
         Removes code styling from self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.uncode()
+            >>> inline = Inline("This is normal text", code=True).uncode()
+            >>> str(inline)
+            'This is normal text'
 
         :return: 
             self
@@ -283,9 +287,11 @@ class Inline(Element):
         """
         Adds link to self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.link("https://snakemd.io")
+            >>> inline = Inline("here").link("https://snakemd.io")
+            >>> str(inline)
+            '[here](https://snakemd.io)'
 
         :param str link: 
             the URL or path to apply to this Inline element
@@ -299,9 +305,11 @@ class Inline(Element):
         """
         Removes link from self.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.unlink()
+            >>> inline = Inline("This is normal text", link="https://snakemd.io").unlink()
+            >>> str(inline)
+            'This is normal text'
 
         :return: 
             self
@@ -314,9 +322,11 @@ class Inline(Element):
         Removes all settings from self (e.g., bold, code, italics, url, etc.).
         All that will remain is the text itself.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            inline.reset()
+            >>> inline = Inline("This is normal text", link="https://snakemd.io", bold=True).reset()
+            >>> str(inline)
+            'This is normal text'
 
         :return: 
             self

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -359,7 +359,7 @@ class Code(Block):
     :param str | Code code:
         the sourcecode to format as a Markdown code block
         
-        - set to a string which represented preformatted code (i.e., whitespace is respected)
+        - set to a string which represents preformatted code (i.e., whitespace is respected)
         - set to a Code object to nest an existing code block
     :param str lang:
         the programming language for the code block; defaults to 'generic'
@@ -422,6 +422,12 @@ class Heading(Block):
         when level < 1 or level > 6
     :param str | Inline | Iterable[Inline | str] text: 
         the heading text
+        
+        - set to a string for unformatted heading text
+        - set to an Inline object to customize the overall styling of the 
+          heading (e.g., bold, link, code, etc.)
+        - set to a "list" of the prior options to provide more granular 
+          control over the individual inline elements in the heading
     :param int level: 
         the heading level between 1 and 6
     """
@@ -711,8 +717,9 @@ class Paragraph(Block):
         (see :class:`snakemd.Raw` for whitespace sensitive applications)
         
         - set to a string for a single line of unformatted text
-        - set to a "list" of text objects for a single line of
-          custom formatted text     
+        - set to a "list" of text objects for more granular control of
+          the individual text objects within the paragraph (e.g., linking,
+          styling, etc.)     
     """
 
     def __init__(self, content: str | Iterable[str | Inline]):

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -1002,15 +1002,10 @@ class Table(Block):
     """
     A table is a standalone block of rows and columns. Data is rendered
     according to underlying Inline items.
-
-    All methods described in the Table class include sample
-    code. Sample code assumes a generic :code:`table` object exists,
-    which can be created as follows:
-
-    .. code-block:: Python
-
+    
+    .. testsetup:: table
+    
         from snakemd import Table
-        table = Table(["Place", "Name"], [["1st", "Crosby"], ["2nd", "McDavid"]])
 
     :raises ValueError: 
     
@@ -1161,24 +1156,43 @@ class Table(Block):
                     widths[i] = width
         return widths
 
-    def add_row(self, row: Iterable[str | Inline | Paragraph]) -> None:
+    def add_row(self, row: Iterable[str | Inline | Paragraph]) -> Table:
         """
         A convenience method which adds a row to the end of table.
         Use this method to build a table row-by-row rather than constructing
         the table rows upfront.  
-
-        .. code-block:: Python
-
-            table.add_row(["3rd", "Matthews"])
+        
+        .. doctest:: table
+        
+            >>> table = Table(["Rank", "Player"], [["1st", "Crosby"], ["2nd", "McDavid"]]).add_row(["3rd", "Matthews"])
+            >>> str(table)
+            '| Rank | Player   |\\n| ---- | -------- |\\n| 1st  | Crosby   |\\n| 2nd  | McDavid  |\\n| 3rd  | Matthews |'
 
         :raises ValueError: 
             when row is not the same width as the table header
         :param Iterable[str | Inline | Paragraph] row: 
             a row of data
+        :return:
+            self
         """
+
+        # Consume row
+        row_list = [_ for _ in row]
+        logger.debug(f"Adding row to table: {row_list}")
+        
+        # Verify that it's safe to add
         if len(row) != len(self._header):
             raise ValueError(
-                f"Unable to add row with width {len(row)} to table with header of width {len(self._header)}"
+                f"Unable to add row with width {len(row_list)} to table with header of width {len(self._header)}"
             )
-        logger.debug(f"Adding row to table: {row}")
-        self._body.append(row)
+        
+        # Add it to table
+        self._body.append(row_list)
+        
+        # Updating widths as needed
+        for i, item in enumerate(row_list):
+            item_width = len(str(item))
+            if item_width > self._widths[i]:
+                self._widths[i] = item_width
+
+        return self

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -72,7 +72,7 @@ class Inline(Element):
         the code state of the inline text
         
         - defaults to :code:`False`
-        - set to :code:`True` to render text as code (i.e., :code:`\`text\``)
+        - set to :code:`True` to render text as code (i.e., ```text```)
     """
 
     def __init__(

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -405,15 +405,10 @@ class Heading(Block):
     A heading is a text block which serves as the title for a new
     section of a document. Headings come in six main sizes which
     correspond to the six headings sizes in HTML (e.g., :code:`<h1>`).
-
-    All methods described in the Heading class include sample
-    code. Sample code assumes a generic :code:`heading` object exists,
-    which can be created as follows:
-
-    .. code-block:: python
-
+    
+    .. testsetup:: heading
+    
         from snakemd import Heading
-        heading = Heading("Sample Heading", 1)
 
     :raises ValueError: 
         when level < 1 or level > 6
@@ -471,17 +466,23 @@ class Heading(Block):
                 for item in text
             ]
 
-    def promote(self) -> None:
+    def promote(self) -> Heading:
         """
         Promotes a heading up a level. Fails silently
         if the heading is already at the highest level (i.e., :code:`<h1>`).
+        
+        .. doctest:: heading
 
-        .. code-block:: Python
-
-            heading.promote()
+            >>> heading = Heading("This is an H2 heading", 3).promote()
+            >>> str(heading)
+            '## This is an H2 heading'
+            
+        :return:
+            self
         """
         if self._level > 1:
             self._level -= 1
+        return self
 
     def demote(self) -> None:
         """

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -524,10 +524,14 @@ class MDList(Block):
         super().__init__()
         self._items: list[Block] = self._process_items(items)
         self._ordered: bool = ordered
-        self._checked = checked
+        self._checked: bool | list[bool] = checked \
+            if checked is None or isinstance(checked, bool) \
+            else [_ for _ in checked]
         self._space = ""
         if isinstance(self._checked, list) and self._top_level_count() != len(self._checked):
-            raise ValueError(f"Number of top-level elements in checklist does not match number of booleans supplied by checked parameter: {self._checked}")
+            raise ValueError(
+                f"Number of top-level elements in checklist does not match number of booleans supplied by checked parameter: {self._checked}"
+            )
 
     def __str__(self) -> str:
         """

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -52,14 +52,20 @@ class Inline(Element):
     :param None | str link: 
         the link (either url or path) associated with the inline element
     :param bool bold: 
-        the bold state of the inline text;
-        set to True to render bold inline text (i.e., True -> **bold**)
+        the bold state of the inline text
+        
+        - defaults to :code:`False`
+        - set to :code:`True` to render bold inline text (i.e., :code:`**bold**`)
     :param bool italics: 
-        the italics state of the inline element;
-        set to True to render inline text in italics (i.e., True -> *italics*)
+        the italics state of the inline element
+        
+        - defaults to :code:`False`
+        - set to :code:`True` to render inline text in italics (i.e., :code:`_italics_`)
     :param bool strikethrough: 
-        the strikethrough state of the inline text;
-        set to True to render inline text with a strikethrough (i.e., True -> ~~strikethrough~~)
+        the strikethrough state of the inline text
+        
+        - defaults to :code:`False`
+        - set to :code:`True` to render inline text with a strikethrough (i.e., :code:`~~strikethrough~~`)
     :param bool code: 
         the italics state of the inline text;
         set to True to render inline text as code (i.e., True -> `code`)
@@ -952,8 +958,9 @@ class Table(Block):
         table = Table(["Place", "Name"], [["1st", "Crosby"], ["2nd", "McDavid"]])
 
     :raises ValueError: 
-        when rows of table are of varying lengths or 
-        when lengths of header and rows of table do not match
+    
+        - when rows of table are of varying lengths
+        - when lengths of header and rows of table do not match
     :param Iterable[str | Inline | Paragraph] header: 
         the header row of labels
     :param Iterable[Iterable[str | Inline | Paragraph]] body: 

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -101,9 +101,9 @@ class Inline(Element):
         
         .. doctest:: inline
 
-            >>> inline = Inline("This is text", bold=True, italics=True)
+            >>> inline = Inline("This is formatted text", bold=True, italics=True)
             >>> str(inline)
-            '_**This is text**_'
+            '_**This is formatted text**_'
 
         :return: 
             the Inline object as a string
@@ -144,9 +144,11 @@ class Inline(Element):
         """
         Checks if the Inline object represents a link.
 
-        .. code-block:: Python
+        .. doctest:: inline
 
-            is_inline_link: bool = inline.is_link()
+            >>> inline = Inline("This is not a link")
+            >>> inline.is_link()
+            False
 
         :return: 
             True if the object has a link; False otherwise

--- a/tests/test_md_list.py
+++ b/tests/test_md_list.py
@@ -1,4 +1,5 @@
 import markdown
+import pytest
 
 from snakemd import Code, Heading, HorizontalRule, Inline, MDList, Paragraph
 
@@ -253,3 +254,27 @@ def test_md_list_nested_checked_iterable_mixed():
         checked=[False, True]
     )
     assert str(outer_list) == "- [ ] Characters\n  - [X] Deku\n  - [X] Bakugo\n  - [ ] Uraraka\n- [X] Powers"
+    
+    
+def test_md_list_checked_exception_list():
+    with pytest.raises(ValueError):
+        MDList(
+            [
+                "Deku", 
+                "Bakugo", 
+                "Uraraka"
+            ], 
+            checked=[True, True]
+        )
+        
+
+def test_md_list_checked_exception_iterable():
+    with pytest.raises(ValueError):
+        MDList(
+            [
+                "Deku", 
+                "Bakugo", 
+                "Uraraka"
+            ], 
+            checked=(x for x in [True, True])
+        )

--- a/tests/test_md_list.py
+++ b/tests/test_md_list.py
@@ -278,3 +278,23 @@ def test_md_list_checked_exception_iterable():
             ], 
             checked=(x for x in [True, True])
         )
+
+    
+def test_md_list_nested_checked_nested_exception_list():
+    with pytest.raises(ValueError):
+        inner_list = MDList(
+            [
+                "Deku", 
+                "Bakugo", 
+                "Uraraka"
+            ], 
+            checked=[True, True, False]
+        )
+        MDList(
+            [
+                "Characters", 
+                inner_list, 
+                "Powers"
+            ], 
+            checked=[False, True, False]
+        )


### PR DESCRIPTION
The plan was to fix #128, which I did. However, this turned out to be more of a docs cleanup pull request in general. In short, I converted all the code snippets to doctests, so they'll never go stale. I also added a proper ValueError for the checklist issue in #128. Things are even setup for the change I'd like to make in #127. 