### PR TITLE
Added Support for Line Breaks in Inline Elements

### DIFF
--- a/docs/version-history.rst
+++ b/docs/version-history.rst
@@ -13,23 +13,23 @@ as follows:
 v2.x
 ----
 
-* v2.3.0 
+* v2.3.0 [:pr:`168`]
 
   * Added a line break option to Inline text to grant a little more control over formatting
 
-* v2.2.1 [:pr:`#164`]
+* v2.2.1 [:pr:`164`]
 
   * Fixed a bug where headings with special characters would not link properly in the table of contents
   * Dropped support for Python 3.8 due to deprecation
   * Added support for Python 3.12 and 3.13
 
-* v2.2.0 [:pr:`#152`, :pr:`153`, :pr:`#159`]
+* v2.2.0 [:pr:`152`, :pr:`153`, :pr:`159`]
   
   * Added documentation throughout the repo
   * Expanded testing
   * Added CSVTable Template and accompanying documentation
 
-* v2.2.0b1 [:pr:`#140`, :pr:`#142`, :pr:`#143`, :pr:`#144`, :pr:`#145`, :pr:`#146`, :pr:`#149`]
+* v2.2.0b1 [:pr:`140`, :pr:`142`, :pr:`143`, :pr:`144`, :pr:`145`, :pr:`146`, :pr:`149`]
 
   * Expanded the Element requirements to include :code:`__repr__()` for developer friendly strings
   * Reworked logging system to take advantage of lazy loading and new :code:`__repr__()` methods

--- a/docs/version-history.rst
+++ b/docs/version-history.rst
@@ -13,6 +13,10 @@ as follows:
 v2.x
 ----
 
+* v2.3.0 
+
+  * Added a line break option to Inline text to grant a little more control over formatting
+
 * v2.2.1 [:pr:`#164`]
 
   * Fixed a bug where headings with special characters would not link properly in the table of contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.poetry]
 name = "SnakeMD"
 description = "A markdown generation library for Python."
-version = "2.2.1"
+version = "2.3.0"
 license = "MIT"
 
 authors = [

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -104,6 +104,11 @@ class Inline(Element):
 
         - defaults to :code:`False`
         - set to :code:`True` to render text as code (i.e., ```text```)
+    :param bool linebreak:
+        the line break state of the inline text
+        
+        - defaults to :code:`False`
+        - set to :code:`True` to add a line break to the end of the element (i.e., `  \n`)
     """
 
     def __init__(
@@ -115,6 +120,7 @@ class Inline(Element):
         italics: bool = False,
         strikethrough: bool = False,
         code: bool = False,
+        linebreak: bool = False,
     ) -> None:
         self._text = text
         self._image = image
@@ -123,6 +129,7 @@ class Inline(Element):
         self._italics = italics
         self._strikethrough = strikethrough
         self._code = code
+        self._linebreak = linebreak
 
     def __str__(self) -> str:
         """
@@ -152,6 +159,8 @@ class Inline(Element):
             text = f"~~{text}~~"
         if self._code:
             text = f"`{text}`"
+        if self._linebreak:
+            text = f"{text}  \n"
         logger.debug("Rendered inline text: %r", text)
         return text
 

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -108,7 +108,7 @@ class Inline(Element):
         the line break state of the inline text
         
         - defaults to :code:`False`
-        - set to :code:`True` to add a line break to the end of the element (i.e., `  \n`)
+        - set to :code:`True` to add a line break to the end of the element (i.e., `<br>`)
     """
 
     def __init__(
@@ -160,7 +160,9 @@ class Inline(Element):
         if self._code:
             text = f"`{text}`"
         if self._linebreak:
-            text = f"{text}  \n"
+            # Note: doing this the markdown way (i.e., space-space-newline)
+            # does not work with the current implementation of Paragraph
+            text = f"{text}<br>"
         logger.debug("Rendered inline text: %r", text)
         return text
 

--- a/snakemd/elements.py
+++ b/snakemd/elements.py
@@ -162,7 +162,7 @@ class Inline(Element):
         if self._linebreak:
             # Note: doing this the markdown way (i.e., space-space-newline)
             # does not work with the current implementation of Paragraph
-            text = f"{text}<br>"
+            text = f"{text}<br />"
         logger.debug("Rendered inline text: %r", text)
         return text
 

--- a/tests/elements/test_inline.py
+++ b/tests/elements/test_inline.py
@@ -204,8 +204,8 @@ def test_inline_code():
 
 def test_inline_linebreak():
     text = Inline("Test", linebreak=True)
-    assert str(text) == "Test<br>"
-    assert markdown.markdown(str(text)) == "<p>Test<br></p>"
+    assert str(text) == "Test<br />"
+    assert markdown.markdown(str(text)) == "<p>Test<br /></p>"
 
 
 # Constructor tests (2-combos)

--- a/tests/elements/test_inline.py
+++ b/tests/elements/test_inline.py
@@ -204,10 +204,8 @@ def test_inline_code():
 
 def test_inline_linebreak():
     text = Inline("Test", linebreak=True)
-    assert str(text) == "Test  \n"
-    # Note: markdown test will not pass because a single line alone
-    # is not enough to trigger the markdown library to generate
-    # a line break: see Paragraph for a working example
+    assert str(text) == "Test<br>"
+    assert markdown.markdown(str(text)) == "<p>Test<br></p>"
 
 
 # Constructor tests (2-combos)

--- a/tests/elements/test_inline.py
+++ b/tests/elements/test_inline.py
@@ -200,6 +200,14 @@ def test_inline_code():
         ")"
     )
     assert markdown.markdown(str(text)) == "<p><code>x = 7</code></p>"
+    
+
+def test_inline_linebreak():
+    text = Inline("Test", linebreak=True)
+    assert str(text) == "Test  \n"
+    # Note: markdown test will not pass because a single line alone
+    # is not enough to trigger the markdown library to generate
+    # a line break: see Paragraph for a working example
 
 
 # Constructor tests (2-combos)

--- a/tests/elements/test_paragraph.py
+++ b/tests/elements/test_paragraph.py
@@ -145,3 +145,11 @@ def test_repr_can_create_object():
     paragraph = Paragraph("")
     obj = eval(repr(paragraph))
     assert isinstance(obj, Paragraph)
+    
+
+def test_paragraph_with_linebreak():
+    paragraph = Paragraph([
+        Inline("First Line", linebreak=True), 
+        Inline("Second Line")
+    ])
+    assert str(paragraph) == "First Line  \nSecond Line"

--- a/tests/elements/test_paragraph.py
+++ b/tests/elements/test_paragraph.py
@@ -152,4 +152,4 @@ def test_paragraph_with_linebreak():
         Inline("First Line", linebreak=True), 
         Inline("Second Line")
     ])
-    assert str(paragraph) == "First Line<br>Second Line"
+    assert str(paragraph) == "First Line<br />Second Line"

--- a/tests/elements/test_paragraph.py
+++ b/tests/elements/test_paragraph.py
@@ -152,4 +152,4 @@ def test_paragraph_with_linebreak():
         Inline("First Line", linebreak=True), 
         Inline("Second Line")
     ])
-    assert str(paragraph) == "First Line  \nSecond Line"
+    assert str(paragraph) == "First Line<br>Second Line"


### PR DESCRIPTION
Most markdown parsers support a line break feature as follows:

```
This line is separate from the following line  
This line is on its own line
```

As long as there are two spaces following the end of the first line, these two lines will render separately as follows:

This line is separate from the following line  
This line is on its own line

The way this works is that markdown parsers will see the two spaces and interpret it as a line break. Therefore, the two spaces will be replaced with a line break tag (i.e., `<br>`). 

To replicate this behavior in SnakeMD, I have added a line break feature to the Inline element. When the line break flag is True, a line break will be added at the end of the Inline element. 

However, because the Paragraph element in SnakeMD removes all whitespace, we can't replicate the line break behavior exactly. As a result, rather than changing the behavior of the Paragraph element (given its potential widespread use), an HTML line break will be produced instead of two spaces.  

I believe this falls in line with the expectations of this library anyway. After all, if the user wants to use markdown, there Raw element should allow them to do so. 